### PR TITLE
Fix publish

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace (
 )
 
 require (
+	get.porter.sh/magefiles v0.2.2
 	get.porter.sh/porter v1.0.0-alpha.13
 	github.com/cnabio/cnab-go v0.23.1
 	github.com/hashicorp/go-hclog v1.0.0
@@ -28,7 +29,6 @@ require (
 )
 
 require (
-	get.porter.sh/magefiles v0.2.0
 	get.porter.sh/operator v0.5.0
 	github.com/carolynvs/magex v0.8.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ contrib.go.opencensus.io/exporter/stackdriver v0.12.1/go.mod h1:iwB6wGarfphGGe/e
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/magefiles v0.2.0 h1:mdoXQlp7iD5FZbbAVLpe9gvv11n2F59uSD+1DJwSD9A=
-get.porter.sh/magefiles v0.2.0/go.mod h1:lwDECEEivbBHACLImnDEhwlr8g3E4xZR1W0DO8FOGa8=
+get.porter.sh/magefiles v0.2.2 h1:9TwJVvIlo+NE1RHNA5FdCciDb0wV4yyp6T3aR7Jtpy8=
+get.porter.sh/magefiles v0.2.2/go.mod h1:lwDECEEivbBHACLImnDEhwlr8g3E4xZR1W0DO8FOGa8=
 get.porter.sh/operator v0.5.0 h1:RqI+QA5y0+3jswop/jAJXnxkr7i1YsFQCgfWXA8Y/I0=
 get.porter.sh/operator v0.5.0/go.mod h1:tuWZiJKx+CKie3uXYB975Py/q2s+ft9SnvNOyia0R4A=
 get.porter.sh/porter v1.0.0-alpha.13 h1:lrhHmO3aSxRZBDUSPunqF/YNyhHKvFhLxrQfhy3g59s=


### PR DESCRIPTION
I've removed the makefile, since it was shelling out to mage anyway. The make targets weren't defined with PHONY, they weren't executing build because that's the name of a directory in the repo.

We now use a fixed version of the magefiles that addresses the duplicate release assets uploaded to the GitHub release that was preventing us from publishing a new release.