### PR TITLE
convert secret key value to lowercase

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -196,11 +196,8 @@ func testLocalIntegration() {
 
 // Run integration tests against the test cluster.
 func TestIntegration() {
-	mg.Deps(XBuildAll, EnsureGinkgo, CleanTestdata)
+	mg.Deps(CleanTestdata, XBuildAll, EnsureGinkgo)
 	mg.Deps(EnsureTestNamespace)
-	defer func() {
-		CleanTestdata()
-	}()
 
 	if os.Getenv("PORTER_AGENT_REPOSITORY") != "" && os.Getenv("PORTER_AGENT_VERSION") != "" {
 		localAgentImgRepository = os.Getenv("PORTER_AGENT_REPOSITORY")

--- a/pkg/kubernetes/secrets/store.go
+++ b/pkg/kubernetes/secrets/store.go
@@ -127,7 +127,7 @@ func SanitizeKey(v string) string {
 	key := strings.ToLower(v)
 	// replace non-alphanumeric characters at the beginning and the end of the string
 	startEndReg := regexp.MustCompile(`^[^a-z0-9]|[^a-z0-9]$`)
-	firstPass := startEndReg.ReplaceAllString(key, "sanitized")
+	firstPass := startEndReg.ReplaceAllString(key, "000")
 	// replace non-alphanumeric characters except `-` and `.` in the string
 	characterReg := regexp.MustCompile(`[^a-z0-9-.]+`)
 	return characterReg.ReplaceAllString(firstPass, "-")

--- a/pkg/kubernetes/secrets/store.go
+++ b/pkg/kubernetes/secrets/store.go
@@ -98,8 +98,9 @@ func (s *Store) Create(ctx context.Context, keyName string, keyValue string, val
 		return err
 	}
 
-	key := strings.ToLower(keyName)
 	s.logger.Debug(fmt.Sprintf("Store.Create: ns:%s, keyName:%s, keyValue:%s", s.namespace, keyName, keyValue))
+
+	key := strings.ToLower(keyName)
 	if key != SecretSourceType {
 		return log.Error(fmt.Errorf("unsupported secret type: %s. Only %s is supported", keyName, SecretSourceType))
 	}
@@ -113,7 +114,7 @@ func (s *Store) Create(ctx context.Context, keyName string, keyValue string, val
 	data := map[string][]byte{
 		SecretDataKey: byteValue,
 	}
-	secret := &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: keyValue}, Immutable: &Immutable, Data: data}
+	secret := &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(keyValue)}, Immutable: &Immutable, Data: data}
 	_, err := s.clientSet.CoreV1().Secrets(s.namespace).Create(ctx, secret, metav1.CreateOptions{})
 	return log.Error(err)
 }

--- a/pkg/kubernetes/secrets/store_test.go
+++ b/pkg/kubernetes/secrets/store_test.go
@@ -1,0 +1,25 @@
+package secrets_test
+
+import (
+	"testing"
+
+	"get.porter.sh/plugin/kubernetes/pkg/kubernetes/secrets"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeKey(t *testing.T) {
+	tests := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{"with non-alphanumeric character at the start and end of the string", "-hello_", "000hello000"},
+		{"with invalid symbols in the string", "-he_*llo.", "000he-llo000"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			require.Equal(t, tt.expected, secrets.SanitizeKey(tt.input), "failed to sanitize input: %s", tt.input)
+		})
+	}
+}

--- a/tests/integration/local/secrets/store_test.go
+++ b/tests/integration/local/secrets/store_test.go
@@ -139,6 +139,15 @@ func TestCreate_Secret(t *testing.T) {
 		require.Equal(t, "testValue", resolved)
 	})
 
+	t.Run("secret key should be all lowercase", func(t *testing.T) {
+		err := store.Create(context.Background(), secrets.SecretSourceType, "UPPERCASE-test", "testValue")
+		require.Error(t, err)
+
+		resolved, err = store.Resolve(context.Background(), secrets.SecretSourceType, "uppercase-test")
+		require.Error(t, err)
+		require.Equal(t, "testValue", resolved)
+	})
+
 	t.Run("exceeded maximum secret value size", func(t *testing.T) {
 		invalidValue := make([]byte, v1.MaxSecretSize+1)
 		err := store.Create(context.Background(), secrets.SecretSourceType, "testkey-max-secret-size", string(invalidValue))

--- a/tests/integration/local/secrets/store_test.go
+++ b/tests/integration/local/secrets/store_test.go
@@ -139,7 +139,7 @@ func TestCreate_Secret(t *testing.T) {
 		require.Equal(t, "testValue", resolved)
 	})
 
-	t.Run("secret key should be converted to follow RFC 1123 subdomain with all lowercase characters", func(t *testing.T) {
+	t.Run("successfully store a secret that doesn't match the secret key naming requirements", func(t *testing.T) {
 		err := store.Create(context.Background(), secrets.SecretSourceType, "-UPPERCA_SE-test-", "testValue")
 		require.NoError(t, err)
 

--- a/tests/integration/local/secrets/store_test.go
+++ b/tests/integration/local/secrets/store_test.go
@@ -143,7 +143,7 @@ func TestCreate_Secret(t *testing.T) {
 		err := store.Create(context.Background(), secrets.SecretSourceType, "UPPERCASE-test", "testValue")
 		require.Error(t, err)
 
-		resolved, err = store.Resolve(context.Background(), secrets.SecretSourceType, "uppercase-test")
+		resolved, err := store.Resolve(context.Background(), secrets.SecretSourceType, "uppercase-test")
 		require.Error(t, err)
 		require.Equal(t, "testValue", resolved)
 	})

--- a/tests/integration/local/secrets/store_test.go
+++ b/tests/integration/local/secrets/store_test.go
@@ -139,12 +139,12 @@ func TestCreate_Secret(t *testing.T) {
 		require.Equal(t, "testValue", resolved)
 	})
 
-	t.Run("secret key should be all lowercase", func(t *testing.T) {
-		err := store.Create(context.Background(), secrets.SecretSourceType, "UPPERCASE-test", "testValue")
-		require.Error(t, err)
+	t.Run("secret key should be converted to follow RFC 1123 subdomain with all lowercase characters", func(t *testing.T) {
+		err := store.Create(context.Background(), secrets.SecretSourceType, "-UPPERCA_SE-test-", "testValue")
+		require.NoError(t, err)
 
-		resolved, err := store.Resolve(context.Background(), secrets.SecretSourceType, "uppercase-test")
-		require.Error(t, err)
+		resolved, err := store.Resolve(context.Background(), secrets.SecretSourceType, "-UPPERCA_SE-test-")
+		require.NoError(t, err)
 		require.Equal(t, "testValue", resolved)
 	})
 

--- a/tests/integration/operator/ginkgo/installation_test.go
+++ b/tests/integration/operator/ginkgo/installation_test.go
@@ -304,7 +304,7 @@ func NewInstallation(installationName, installationNamespace string) *porterv1.I
 			Name:          installationName,
 			Namespace:     installationNamespace,
 			Bundle: porterv1.OCIReferenceParts{
-				Repository: "ghcr.io/vinozzz/porter-test-me",
+				Repository: "ghcr.io/getporter/test/kubernetes-plugin",
 				Version:    "0.1.0",
 			},
 			Parameters:     runtime.RawExtension{Raw: []byte("{\"delay\": \"1\", \"exitStatus\": \"0\"}")},

--- a/tests/integration/operator/ginkgo/installation_test.go
+++ b/tests/integration/operator/ginkgo/installation_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	porterv1 "get.porter.sh/operator/api/v1"
@@ -38,8 +39,8 @@ var _ = Describe("Porter using default secrets plugin config", func() {
 			installationName := fmt.Sprintf("default-plugin-%v", randId)
 			ns := createTestNamespace(context.Background())
 			ctx := context.Background()
-			createSecret(ns, secrets.SecretDataKey, "password", "test")
-			credSet := NewCredSet("test", "insecureValue", "password")
+			createSecret(ns, secrets.SecretDataKey, "cred-password", "test")
+			credSet := NewCredSet("test", "insecureValue", "cred-password")
 			agentAction := createCredentialSetAgentAction(ns, credSet)
 			pollAA := func() bool { return agentActionPoll(agentAction) }
 			Eventually(pollAA, time.Second*120, time.Second*3).Should(BeTrue())
@@ -64,8 +65,8 @@ var _ = Describe("Porter using default secrets plugin config", func() {
 			installationName := fmt.Sprintf("default-plugin-%v", randId)
 			installationNs := createTestNamespace(ctx)
 			secretsNs := createTestNamespace(ctx)
-			createSecret(secretsNs, secrets.SecretDataKey, "password", "test")
-			credSet := NewCredSet("test", "insecureValue", "password")
+			createSecret(secretsNs, secrets.SecretDataKey, "cred-password", "test")
+			credSet := NewCredSet("test", "insecureValue", "cred-password")
 			agentAction := createCredentialSetAgentAction(installationNs, credSet)
 			pollAA := func() bool { return agentActionPoll(agentAction) }
 			Eventually(pollAA, time.Second*120, time.Second*3).Should(BeTrue())
@@ -89,8 +90,8 @@ var _ = Describe("Porter using default secrets plugin config", func() {
 			ctx := context.Background()
 			installationName := fmt.Sprintf("default-plugin-%v", randId)
 			installationNs := createTestNamespace(ctx)
-			createSecret(installationNs, "invalidKey", "password", "test")
-			credSet := NewCredSet("test", "insecureValue", "password")
+			createSecret(installationNs, "invalidKey", "cred-password", "test")
+			credSet := NewCredSet("test", "insecureValue", "cred-password")
 			agentAction := createCredentialSetAgentAction(installationNs, credSet)
 			pollAA := func() bool { return agentActionPoll(agentAction) }
 			Eventually(pollAA, time.Second*120, time.Second*3).Should(BeTrue())
@@ -119,13 +120,13 @@ var _ = Describe("Porter using a secrets plugin config that doesn't specify the 
 			defaultSecretsCfgName := "kubernetes-secrets"
 			ns := createTestNamespace(context.Background())
 			ctx := context.Background()
-			createSecret(ns, secrets.SecretDataKey, "password", "test")
+			createSecret(ns, secrets.SecretDataKey, "cred-password", "test")
 			porterCfg := NewPorterConfig(ns)
 			k8sSecretsCfg := NewSecretsPluginConfig(defaultSecretsCfgName, nil)
 			SetPorterConfigSecrets(porterCfg, k8sSecretsCfg)
 			porterCfg.Spec.DefaultSecrets = pointer.String(defaultSecretsCfgName)
 			Expect(k8sClient.Create(context.Background(), porterCfg)).Should(Succeed())
-			credSet := NewCredSet("test", "insecureValue", "password")
+			credSet := NewCredSet("test", "insecureValue", "cred-password")
 			agentAction := createCredentialSetAgentAction(ns, credSet)
 			pollAA := func() bool { return agentActionPoll(agentAction) }
 			Eventually(pollAA, time.Second*120, time.Second*3).Should(BeTrue())
@@ -158,7 +159,7 @@ var _ = Describe("Porter using secrets plugin configured using same namespace as
 			installationName := fmt.Sprintf("porter-hello-%v", randId)
 			ns := createTestNamespace(context.Background())
 			ctx := context.Background()
-			createSecret(ns, secrets.SecretDataKey, "password", "test")
+			createSecret(ns, secrets.SecretDataKey, "cred-password", "test")
 			defaultSecretsCfgName := "kubernetes-secrets"
 			porterCfg := NewPorterConfig(ns)
 			secretsNamespaceCfg := &SecretsConfig{Namespace: ns}
@@ -166,7 +167,7 @@ var _ = Describe("Porter using secrets plugin configured using same namespace as
 			SetPorterConfigSecrets(porterCfg, k8sSecretsCfg)
 			porterCfg.Spec.DefaultSecrets = pointer.String(defaultSecretsCfgName)
 			Expect(k8sClient.Create(context.Background(), porterCfg)).Should(Succeed())
-			credSet := NewCredSet("test", "insecureValue", "password")
+			credSet := NewCredSet("test", "insecureValue", "cred-password")
 			agentAction := createCredentialSetAgentAction(ns, credSet)
 			pollAA := func() bool { return agentActionPoll(agentAction) }
 			Eventually(pollAA, time.Second*120, time.Second*3).Should(BeTrue())
@@ -184,6 +185,53 @@ var _ = Describe("Porter using secrets plugin configured using same namespace as
 			validateInstallStatus(inst, porterv1.PhaseSucceeded)
 		})
 	})
+
+	When("applying an Installation with a sensitive parameter in the Installation namespace", func() {
+		It("successfully installs", func() {
+			By("storing secrets in the kubernetes secret")
+			randId := uuid.New()
+			installationName := fmt.Sprintf("porter-hello-secret-%v", randId)
+			ns := createTestNamespace(context.Background())
+			ctx := context.Background()
+			createSecret(ns, secrets.SecretDataKey, "cred-test", "test")
+			defaultSecretsCfgName := "kubernetes-secrets"
+			porterCfg := NewPorterConfig(ns)
+			secretsNamespaceCfg := &SecretsConfig{Namespace: ns}
+			k8sSecretsCfg := NewSecretsPluginConfig(defaultSecretsCfgName, secretsNamespaceCfg)
+			SetPorterConfigSecrets(porterCfg, k8sSecretsCfg)
+			porterCfg.Spec.DefaultSecrets = pointer.String(defaultSecretsCfgName)
+			Expect(k8sClient.Create(context.Background(), porterCfg)).Should(Succeed())
+			credSet := NewCredSet("test", "insecureValue", "cred-test")
+			agentAction := createCredentialSetAgentAction(ns, credSet)
+			pollAA := func() bool { return agentActionPoll(agentAction) }
+			Eventually(pollAA, time.Second*120, time.Second*3).Should(BeTrue())
+			inst := NewInstallation(installationName, ns)
+			inst.Spec.Parameters = runtime.RawExtension{Raw: []byte("{\"delay\": \"1\", \"exitStatus\": \"0\", \"password\": \"super-secret\"}")}
+			Expect(k8sClient.Create(ctx, inst)).Should(Succeed())
+
+			// Wait for the job to be created
+			installations := waitForInstallationStarted(ctx, ns, installationName)
+			installation := installations.Items[0]
+
+			// Validate that the job succeeded
+			installation = waitForInstallationFinished(ctx, installation)
+
+			// Validate that the installation status was updated
+			validateInstallStatus(inst, porterv1.PhaseSucceeded)
+			secretList := &corev1.SecretList{}
+			Expect(k8sClient.List(ctx, secretList, client.InNamespace(ns))).Should(Succeed())
+			var found bool
+			for _, s := range secretList.Items {
+				if !strings.Contains(s.ObjectMeta.Name, "password") {
+					continue
+				}
+				if value, ok := s.Data[secrets.SecretDataKey]; ok {
+					found = string(value) == "super-secret"
+				}
+			}
+			Expect(found).Should(BeTrue())
+		})
+	})
 })
 
 var _ = Describe("Porter k8s secrets plugin configured using a different namespace than the Installation resource", func() {
@@ -195,7 +243,7 @@ var _ = Describe("Porter k8s secrets plugin configured using a different namespa
 			installNamespace := createTestNamespace(context.Background())
 			secretNamespace := createTestNamespace(context.Background())
 			ctx := context.Background()
-			var defaultSecretsCfgName, secretName, secretValue, credSetName = "kubernetes-secrets", "password", "test", "test"
+			var defaultSecretsCfgName, secretName, secretValue, credSetName = "kubernetes-secrets", "cred-password", "test", "test"
 			createSecret(secretNamespace, secrets.SecretDataKey, secretName, secretValue)
 			porterCfg := NewPorterConfig(installNamespace)
 			secretsNamespaceCfg := &SecretsConfig{Namespace: secretNamespace}
@@ -256,8 +304,8 @@ func NewInstallation(installationName, installationNamespace string) *porterv1.I
 			Name:          installationName,
 			Namespace:     installationNamespace,
 			Bundle: porterv1.OCIReferenceParts{
-				Repository: "ghcr.io/bdegeeter/porter-test-me",
-				Version:    "0.2.0",
+				Repository: "ghcr.io/vinozzz/porter-test-me",
+				Version:    "0.1.0",
 			},
 			Parameters:     runtime.RawExtension{Raw: []byte("{\"delay\": \"1\", \"exitStatus\": \"0\"}")},
 			CredentialSets: []string{"test"},

--- a/tests/integration/operator/testdata/porter-test-me.yaml
+++ b/tests/integration/operator/testdata/porter-test-me.yaml
@@ -7,7 +7,7 @@ spec:
   namespace: dev
   name: foo2
   bundle:
-    repository: ghcr.io/vinozzz/porter-test-me
+    repository: ghcr.io/getporter/test/kubernetes-plugin
     version: 0.1.0
   parameters:
     delay: 0

--- a/tests/integration/operator/testdata/porter-test-me.yaml
+++ b/tests/integration/operator/testdata/porter-test-me.yaml
@@ -1,4 +1,3 @@
-schemaVersion: 1.0.0-alpha.1
 apiVersion: porter.sh/v1
 kind: Installation
 metadata:
@@ -8,10 +7,11 @@ spec:
   namespace: dev
   name: foo2
   bundle:
-    repository: ghcr.io/bdegeeter/porter-test-me
-    version: 0.2.0
+    repository: ghcr.io/vinozzz/porter-test-me
+    version: 0.1.0
   parameters:
     delay: 0
     exitStatus: 0
+    password: super-secret
   credentialSets:
     - test

--- a/tests/integration/operator/testdata/porter-test-me/Dockerfile.tmpl
+++ b/tests/integration/operator/testdata/porter-test-me/Dockerfile.tmpl
@@ -1,0 +1,21 @@
+FROM debian:stretch-slim
+
+ARG BUNDLE_DIR
+
+RUN apt-get update && apt-get install -y ca-certificates jq
+
+# This is a template Dockerfile for the bundle's invocation image
+# You can customize it to use different base images, install tools and copy configuration files.
+#
+# Porter will use it as a template and append lines to it for the mixins
+# and to set the CMD appropriately for the CNAB specification.
+#
+# Add the following line to porter.yaml to instruct Porter to use this template
+# dockerfile: Dockerfile.tmpl
+
+# You can control where the mixin's Dockerfile lines are inserted into this file by moving "# PORTER_MIXINS" line
+# another location in this file. If you remove that line, the mixins generated content is appended to this file.
+# PORTER_MIXINS
+
+# Use the BUNDLE_DIR build argument to copy files into the bundle
+COPY . $BUNDLE_DIR

--- a/tests/integration/operator/testdata/porter-test-me/porter.yaml
+++ b/tests/integration/operator/testdata/porter-test-me/porter.yaml
@@ -4,10 +4,10 @@
 # Uncomment out the sections below to take full advantage of what Porter can do!
 
 schemaVersion: 1.0.0-alpha.1
-name: porter-test-me
+name: kubernetes-plugin
 version: 0.1.0
 description: "Porter bundle with test behaviors"
-registry: ghcr.io/vinozzz
+registry: ghcr.io/getporter/test
 
 # If you want to customize the Dockerfile in use, uncomment the line below and update the referenced file.
 # See https://porter.sh/custom-dockerfile/

--- a/tests/integration/operator/testdata/porter-test-me/porter.yaml
+++ b/tests/integration/operator/testdata/porter-test-me/porter.yaml
@@ -1,0 +1,101 @@
+# This is the configuration for Porter
+# You must define steps for each action, but the rest is optional
+# See https://porter.sh/author-bundles for documentation on how to configure your bundle
+# Uncomment out the sections below to take full advantage of what Porter can do!
+
+schemaVersion: 1.0.0-alpha.1
+name: porter-test-me
+version: 0.1.0
+description: "Porter bundle with test behaviors"
+registry: ghcr.io/vinozzz
+
+# If you want to customize the Dockerfile in use, uncomment the line below and update the referenced file.
+# See https://porter.sh/custom-dockerfile/
+dockerfile: Dockerfile.tmpl
+
+mixins:
+  - exec
+
+# Below is an example of how to define credentials
+# See https://porter.sh/author-bundles/#credentials
+credentials:
+  - name: insecureValue
+    description: insecure test credential
+    env: INSECURE_VALUE
+    required: false
+
+# Below is an example of how to define parameters
+# See https://porter.sh/author-bundles/#parameters
+parameters:
+  - name: exitStatus
+    description: control exit status code
+    type: integer
+    default: 0
+    minimum: 0
+
+  - name: delay
+    description: sleep (in seconds) before exiting
+    type: integer
+    default: 0
+    minimum: 0
+
+  - name: password
+    description: super secret password
+    type: string
+    default: default-value
+    sensitive: true
+
+outputs:
+  - name: outAction
+    description: bundle action
+    type: string
+  - name: outDelay
+    description: delay parameter value
+    type: integer
+  - name: outExitStatus
+    description: exitStatus parameter value
+    type: integer
+  - name: outInsecureValue
+    description: insecureValue secret value
+    type: string
+  - name: outSecureValue
+    description: secureValue secret value
+    type: string
+    sensitive: true
+
+install:
+  - exec:
+      description: "test install"
+      command: ./test-me.sh
+      arguments:
+        - install
+        - "{{ bundle.parameters.delay }}"
+        - "{{ bundle.parameters.exitStatus }}"
+        - "{{ bundle.parameters.password }}"
+      outputs:
+        - name: outAction
+          jsonPath: "$.config.action"
+        - name: outDelay
+          jsonPath: "$.config.parameters.delay"
+        - name: outExitStatus
+          jsonPath: "$.config.parameters.exitStatus"
+        - name: outSecureValue
+          jsonPath: "$.config.parameters.password"
+        - name: outInsecureValue
+          jsonPath: "$.credentials.insecureValue"
+
+uninstall:
+  - exec:
+      description: "test uninstall"
+      command: ./test-me.sh
+      arguments:
+        - uninstall
+        - "{{ bundle.parameters.delay }}"
+        - "{{ bundle.parameters.exitStatus }}"
+      outputs:
+        - name: outAction
+          jsonPath: "$.config.action"
+        - name: outDelay
+          jsonPath: "$.config.parameters.delay"
+        - name: outExitStatus
+          jsonPath: "$.config.parameters.exitStatus"

--- a/tests/integration/operator/testdata/porter-test-me/test-me.sh
+++ b/tests/integration/operator/testdata/porter-test-me/test-me.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+action=${1}
+delay=${2}
+exitCode=${3}
+password=${4}
+insecureValue=${INSECURE_VALUE:-default}
+
+jsonOut=$(jq -n \
+  --arg action ${action} \
+  --arg delay ${delay} \
+  --arg exitStatus ${exitCode} \
+  --arg password ${password} \
+  --arg insecureValue ${insecureValue} \
+  '{"config": { "action":$action, "parameters":{"delay":$delay|tonumber, "exitStatus":$exitStatus|tonumber, "password":$password }}, "credentials": {"insecureValue":$insecureValue}}')
+
+sleep ${delay}
+echo ${jsonOut} | jq .
+exit ${exitCode}


### PR DESCRIPTION
```
a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', 
and must start and end with an alphanumeric character (e.g. 'example.com', 
regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```
kubernetes requires the object name has to be all lowercase. This PR fixes that when storing sensitive data into kubernetes secrets
#115 