### PR TITLE
Bump magex to v0.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,20 +11,19 @@ jobs:
         working-directory: ./
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Cache
-        uses: actions/cache@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Set up Go
-        uses: actions/setup-go@v2
+          fetch-depth: 0 # Get all git history
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
       - name: Set up Mage
         run: go run mage.go EnsureMage
       - name: Test Integration

--- a/build/azure-pipelines-pr.yml
+++ b/build/azure-pipelines-pr.yml
@@ -4,10 +4,13 @@ pr:
 trigger: none
 
 pool:
-  vmImage: "Ubuntu 18.04"
+  vmImage: "ubuntu-latest"
 
 variables:
-  GOVERSION: "1.17.7"
+  GOVERSION: "1.18.4"
+
+env:
+  MAGEFILE_VERBOSE: true
 
 steps:
   - template: build-and-test.yml

--- a/build/azure-pipelines-pr.yml
+++ b/build/azure-pipelines-pr.yml
@@ -9,8 +9,5 @@ pool:
 variables:
   GOVERSION: "1.18.4"
 
-env:
-  MAGEFILE_VERBOSE: true
-
 steps:
   - template: build-and-test.yml

--- a/build/azure-pipelines-release.yml
+++ b/build/azure-pipelines-release.yml
@@ -8,10 +8,13 @@ trigger:
 pr: none
 
 pool:
-  vmImage: "Ubuntu 18.04"
+  vmImage: "ubuntu-latest"
+
+env:
+  MAGEFILE_VERBOSE: true
 
 variables:
-  GOVERSION: "1.17.7"
+  GOVERSION: "1.18.4"
   tag: $[replace(variables['Build.SourceBranch'],'refs/tags/','')]
 
 steps:

--- a/build/azure-pipelines-release.yml
+++ b/build/azure-pipelines-release.yml
@@ -10,9 +10,6 @@ pr: none
 pool:
   vmImage: "ubuntu-latest"
 
-env:
-  MAGEFILE_VERBOSE: true
-
 variables:
   GOVERSION: "1.18.4"
   tag: $[replace(variables['Build.SourceBranch'],'refs/tags/','')]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module get.porter.sh/plugin/kubernetes
 go 1.17
 
 replace (
-	get.porter.sh/magefiles => github.com/carolynvs/magefiles v0.1.3-0.20220727152744-3c269f8ed65b
+	get.porter.sh/magefiles => github.com/carolynvs/magefiles v0.1.3-0.20220727164202-ac6a18291d25
 
 	// Use the same replace that Porter uses. These our are long-term patches.
 	github.com/hashicorp/go-plugin => github.com/getporter/go-plugin v1.4.4-porter.1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module get.porter.sh/plugin/kubernetes
 go 1.17
 
 replace (
+	get.porter.sh/magefiles => github.com/carolynvs/magefiles v0.1.3-0.20220727152744-3c269f8ed65b
+
 	// Use the same replace that Porter uses. These our are long-term patches.
 	github.com/hashicorp/go-plugin => github.com/getporter/go-plugin v1.4.4-porter.1
 
@@ -27,7 +29,7 @@ require (
 
 require (
 	get.porter.sh/operator v0.6.0
-	github.com/carolynvs/magex v0.8.1
+	github.com/carolynvs/magex v0.9.0
 	github.com/google/uuid v1.3.0
 	github.com/magefile/mage v1.13.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMS
 github.com/carolynvs/aferox v0.3.0 h1:CMT50zX88amTMbFfFIWSTKRVRaOw6sejUMbbKiCD4zE=
 github.com/carolynvs/aferox v0.3.0/go.mod h1:eb7CHGIO33CCZS//xtnblvPZbuuZMv0p1VbhiSwZnH4=
 github.com/carolynvs/datetime-printer v0.2.0/go.mod h1:p9W8ZUhmQUOVD5kiDuGXwRG65/nTkZWlLylY7s+Qw2k=
-github.com/carolynvs/magefiles v0.1.3-0.20220727152744-3c269f8ed65b h1:h5BkDiyKORa1Hph+QbuEhkHQUALa4edPL0mOAWhA1yE=
-github.com/carolynvs/magefiles v0.1.3-0.20220727152744-3c269f8ed65b/go.mod h1:Ot9MFPKNMURyrGZYUOTI8SkswCbbY03XQx/B7SWcvdE=
+github.com/carolynvs/magefiles v0.1.3-0.20220727164202-ac6a18291d25 h1:b6qaFOwihiMPqX/fTWi+mXUneqRoBS/ueRif+Bf2xWc=
+github.com/carolynvs/magefiles v0.1.3-0.20220727164202-ac6a18291d25/go.mod h1:Ot9MFPKNMURyrGZYUOTI8SkswCbbY03XQx/B7SWcvdE=
 github.com/carolynvs/magex v0.8.0/go.mod h1:vZB3BkRfkd5ZMtkxJkCGbdFyWGoZiuNPKhx6uEQARmY=
 github.com/carolynvs/magex v0.8.1/go.mod h1:aBJBqUIBFyatSGOv0Ak6j8U+9PzotM600G6Dz0Df1Wg=
 github.com/carolynvs/magex v0.8.2-0.20220725154022-8303d8738552/go.mod h1:H1LW6RYJ/sNbisMmPe9E73aJZa8geKLKK9mBWLWz3ek=

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,6 @@ cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKP
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
-cloud.google.com/go v0.81.0 h1:at8Tk2zUz63cLPR0JPWm5vp77pEZmzxEQBEfRKn1VV8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
 cloud.google.com/go v0.83.0/go.mod h1:Z7MJUsANfY0pYPdw0lbnivPx4/vhy/e2FEkSkF7vAVY=
 cloud.google.com/go v0.84.0/go.mod h1:RazrYuxIK6Kb7YrzzhPoLmCVzl7Sup4NrbKPg8KHSUM=
@@ -75,9 +74,6 @@ contrib.go.opencensus.io/exporter/stackdriver v0.12.1/go.mod h1:iwB6wGarfphGGe/e
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/magefiles v0.3.0/go.mod h1:lwDECEEivbBHACLImnDEhwlr8g3E4xZR1W0DO8FOGa8=
-get.porter.sh/magefiles v0.3.1 h1:YdjBTzPbwHTq22XaJL69DO79mCQosHCMtWbOyCr7OsA=
-get.porter.sh/magefiles v0.3.1/go.mod h1:lwDECEEivbBHACLImnDEhwlr8g3E4xZR1W0DO8FOGa8=
 get.porter.sh/operator v0.6.0 h1:TBuLJnirdF5KO76zZkqID7QMtnOkiAuCoYML+SyM1is=
 get.porter.sh/operator v0.6.0/go.mod h1:l9fPVPMCfISc6tk60qmPtgoyB+lU2aWeeD8r84Pp+hg=
 get.porter.sh/porter v1.0.0-beta.1 h1:QYHPcW/HmqkhIMlWTD+siNuao7kdFfzc1a6CpFK1s+M=
@@ -297,9 +293,13 @@ github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMS
 github.com/carolynvs/aferox v0.3.0 h1:CMT50zX88amTMbFfFIWSTKRVRaOw6sejUMbbKiCD4zE=
 github.com/carolynvs/aferox v0.3.0/go.mod h1:eb7CHGIO33CCZS//xtnblvPZbuuZMv0p1VbhiSwZnH4=
 github.com/carolynvs/datetime-printer v0.2.0/go.mod h1:p9W8ZUhmQUOVD5kiDuGXwRG65/nTkZWlLylY7s+Qw2k=
+github.com/carolynvs/magefiles v0.1.3-0.20220727152744-3c269f8ed65b h1:h5BkDiyKORa1Hph+QbuEhkHQUALa4edPL0mOAWhA1yE=
+github.com/carolynvs/magefiles v0.1.3-0.20220727152744-3c269f8ed65b/go.mod h1:Ot9MFPKNMURyrGZYUOTI8SkswCbbY03XQx/B7SWcvdE=
 github.com/carolynvs/magex v0.8.0/go.mod h1:vZB3BkRfkd5ZMtkxJkCGbdFyWGoZiuNPKhx6uEQARmY=
-github.com/carolynvs/magex v0.8.1 h1:7QYsqIANzYbj9fgE3fJWOJf+DfkD0Ymr8kz0kNhXxFM=
 github.com/carolynvs/magex v0.8.1/go.mod h1:aBJBqUIBFyatSGOv0Ak6j8U+9PzotM600G6Dz0Df1Wg=
+github.com/carolynvs/magex v0.8.2-0.20220725154022-8303d8738552/go.mod h1:H1LW6RYJ/sNbisMmPe9E73aJZa8geKLKK9mBWLWz3ek=
+github.com/carolynvs/magex v0.9.0 h1:fWe7oshGv6zuei5Z6EI95RSlOKjIifBZ26myB9G+m/I=
+github.com/carolynvs/magex v0.9.0/go.mod h1:H1LW6RYJ/sNbisMmPe9E73aJZa8geKLKK9mBWLWz3ek=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=

--- a/magefile.go
+++ b/magefile.go
@@ -58,7 +58,7 @@ const (
 	operatorImage    = "porter-operator"
 	operatorRegistry = "ghcr.io/getporter"
 	// Porter version to use
-	porterVersion = "canary-v1"
+	porterVersion = "v1.0.0-beta.1"
 	// Docker registry for porter client container
 	porterRegistry   = "ghcr.io/getporter"
 	porterConfigFile = "./tests/integration/operator/testdata/operator_porter_config.yaml"

--- a/tests/integration/operator/ginkgo/installation_test.go
+++ b/tests/integration/operator/ginkgo/installation_test.go
@@ -300,7 +300,7 @@ func NewInstallation(installationName, installationNamespace string) *porterv1.I
 			Namespace: installationNamespace,
 		},
 		Spec: porterv1.InstallationSpec{
-			SchemaVersion: "1.0.1",
+			SchemaVersion: "1.0.2",
 			Name:          installationName,
 			Namespace:     installationNamespace,
 			Bundle: porterv1.OCIReferenceParts{

--- a/tests/integration/operator/testdata/porter-test-me.yaml
+++ b/tests/integration/operator/testdata/porter-test-me.yaml
@@ -3,7 +3,7 @@ kind: Installation
 metadata:
   name: porter-test-me2
 spec:
-  schemaVersion: 1.0.1
+  schemaVersion: 1.0.2
   namespace: dev
   name: foo2
   bundle:


### PR DESCRIPTION
This updates to magex@v0.9.0 and also our magefiles to the most recent version.
