### PR TITLE
Fix release lag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 kind.config
 coverage-integration.out
 build/git_askpass.sh
+hack/arm-mongodb-vals.yaml

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace (
 )
 
 require (
-	get.porter.sh/magefiles v0.5.0
+	get.porter.sh/magefiles v0.5.1
 	get.porter.sh/operator v0.7.4
 	get.porter.sh/porter v1.0.9
 	github.com/carolynvs/magex v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/magefiles v0.5.0 h1:Hy/DgS0l+9TlEKcHKMPBCpzIRCKUs13wasT+T8S6P+A=
-get.porter.sh/magefiles v0.5.0/go.mod h1:KzKenKVauKKDhZ5FERVhqSz8m/xVSsRzOPseDA4UDIE=
+get.porter.sh/magefiles v0.5.1 h1:TUDxM/JoQjGnQ0YHxWr+Ko4Y8h/ETAMgW38jzN3fgBM=
+get.porter.sh/magefiles v0.5.1/go.mod h1:KzKenKVauKKDhZ5FERVhqSz8m/xVSsRzOPseDA4UDIE=
 get.porter.sh/operator v0.7.4 h1:eoEWYmuKPx9G4d6jo4f8OwPDdcjx/y6XlawwOf5HMqg=
 get.porter.sh/operator v0.7.4/go.mod h1:T0mXGFr4Kb7zK1v+6Xsq4qvU1s7lw/4cn0DaLerEXWE=
 get.porter.sh/porter v1.0.9 h1:oRjK6cqDVxk2bNlwyWoyLdIYClYz5J4SmPjbxOOQLFE=


### PR DESCRIPTION
Update to magefiles v0.5.1 which ensures that releases stay in draft until the assets are successfully uploaded.

Related to https://github.com/getporter/porter/issues/2723