### PR TITLE
Use porter from bin during CI

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -85,13 +85,16 @@ var operatorBundleRef = fmt.Sprintf("%s/%s:%s", operatorRegistry, operatorImage,
 // Build a command that stops the build on if the command fails
 var must = shx.CommandBuilder{StopOnError: true}
 
-// Publish the cross-compiled binaries.
+// Publish uploads the cross-compiled binaries for the plugin
 func Publish() {
+	mg.SerialDeps(porter.UseBinForPorterHome, porter.EnsurePorter)
+
+	releases.PreparePluginForPublish(pluginName)
 	releases.PublishPlugin(pluginName)
 	releases.PublishPluginFeed(pluginName)
 }
 
-// Test out publish locally, with your github forks
+// TestPublish tries out publish locally, with your github forks
 // Assumes that you forked and kept the repository name unchanged.
 func TestPublish(username string) {
 	pluginRepo := fmt.Sprintf("github.com/%s/%s-plugins", username, pluginName)


### PR DESCRIPTION
When we are working with Porter in CI, we should install porter into the bin/ directory and use it from there. The magefiles repository assumes porter is installed in the bin for actions like publishing the atom feed.