### PR TITLE
Switch log level for messages from info to debug

### DIFF
--- a/pkg/kubernetes/secrets/plugin.go
+++ b/pkg/kubernetes/secrets/plugin.go
@@ -35,7 +35,7 @@ func NewPlugin(cxt *portercontext.Context, pluginConfig config.Config) (hplugin.
 		JSONFormat: true,
 	})
 	cfg := PluginConfig{Logger: logger, Namespace: pluginConfig.Namespace}
-	logger.Info(fmt.Sprintf("NewPlugin.Config.Namespace: %s", cfg.Namespace))
+	logger.Debug(fmt.Sprintf("NewPlugin.Config.Namespace: %s", cfg.Namespace))
 	if err := mapstructure.Decode(pluginConfig, &cfg); err != nil {
 		return nil, errors.Wrapf(err, "error decoding %s plugin config from %#v", PluginKey, pluginConfig)
 	}

--- a/pkg/kubernetes/secrets/store.go
+++ b/pkg/kubernetes/secrets/store.go
@@ -51,13 +51,13 @@ func (s *Store) connect() error {
 	if s.clientSet != nil {
 		return nil
 	}
-	s.logger.Info(fmt.Sprintf("Store.connect: pre-clientset %s : %s", "namespace", s.namespace))
+	s.logger.Debug(fmt.Sprintf("Store.connect: pre-clientset %s : %s", "namespace", s.namespace))
 	clientSet, namespace, err := k8shelper.GetClientSet(s.namespace)
 	if err != nil {
 		return err
 	}
 	s.namespace = *namespace
-	s.logger.Info(fmt.Sprintf("Store.connect: post-clientset %s : %s", "namespace", s.namespace))
+	s.logger.Debug(fmt.Sprintf("Store.connect: post-clientset %s : %s", "namespace", s.namespace))
 
 	s.clientSet = clientSet
 


### PR DESCRIPTION
Porter now passes and handles log levels for plugins in a different way. This means that the messages would be present even when verbosity is set to `info` - which can garble the data when requesting to show the output as everything is sent to `stdout`.

Introduced in porter 1.2.0

Behavior in porter <1.2.0:
```
$ porter installations output show my_output -i my-bundle
data-from-output
```

Behavior in porter >1.2.0
```
$ porter installations output show my_output -i my-bundle
NewPlugin.Config.Namespace: porter-system
Store.connect: pre-clientset namespace : porter-system
Store.connect: post-clientset namespace : porter-system
data-from-output
```

This extra messages can be hidden by setting verbosity to `error` or `warn` but I think a better behavior is to hide them in the normal use case (ie. with verbosity set to `info`).

Behavior after my changes with porter >1.2.0:
```
$ porter installations output show my_output -i my-bundle
data-from-output

$ porter installations output show my_output -i my-bundle --verbosity debug
<snipped>
NewPlugin.Config.Namespace: porter-system
using plugin
plugin address
Store.connect: pre-clientset namespace : porter-system
Store.connect: post-clientset namespace : porter-system
Store.Resolve: ns:porter-system, keyName:secret, keyValue:01JHJ2KQ2QQQ0KQ4DJ75X75D2P-my_output
data-from-output
```